### PR TITLE
Refactor/02 db di

### DIFF
--- a/app/db/pool.py
+++ b/app/db/pool.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import psycopg
+
+logger = logging.getLogger("app.db.pool")
+
+# Try to use psycopg-pool if available; otherwise we still allow /readyz to work
+try:  # psycopg-pool is a separate package
+    from psycopg_pool import AsyncConnectionPool  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    AsyncConnectionPool = None  # type: ignore[misc,assignment]
+
+_pool: AsyncConnectionPool | None = None  # type: ignore[name-defined]
+
+
+async def init_pool() -> None:
+    """
+    Initialize a global async connection pool.
+    - DSN comes from DATABASE_URL.
+    - If psycopg-pool isn't installed or DSN missing, we skip pooling (readyz will degrade).
+    """
+    global _pool
+    if _pool is not None:
+        return
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.warning("DATABASE_URL not set; DB pool not initialized")
+        return
+
+    # If pool package isn't present, log and don't crash.
+    if AsyncConnectionPool is None:
+        logger.warning("psycopg-pool not installed; skipping pool initialization")
+        return
+
+    # Sane defaults; adjust later if needed via env vars
+    min_size = int(os.environ.get("DB_MIN_SIZE", "1"))
+    max_size = int(os.environ.get("DB_MAX_SIZE", "5"))
+    connect_timeout = float(os.environ.get("DB_CONNECT_TIMEOUT", "5"))
+
+    _pool = AsyncConnectionPool(
+        dsn,
+        min_size=min_size,
+        max_size=max_size,
+        timeout=connect_timeout,  # connect timeout
+    )
+    # Explicitly open the pool once, so failures are logged at startup
+    await _pool.open()
+    logger.info(
+        "DB pool initialized (min=%s, max=%s, timeout=%ss)", min_size, max_size, connect_timeout
+    )
+
+
+def get_pool() -> AsyncConnectionPool | None:  # type: ignore[name-defined]
+    """Return the pool if initialized (or None)."""
+    return _pool
+
+
+async def check_ready() -> bool:
+    """
+    True if we can get a connection.
+    - With pool: try pool.connection().
+    - Without pool (or missing package): try a one-off AsyncConnection (best-effort).
+    """
+    dsn = os.environ.get("DATABASE_URL")
+
+    # If we have a pool, prefer that.
+    if _pool is not None:
+        try:
+            async with _pool.connection() as _:
+                return True
+        except Exception:
+            return False
+
+    # No pool? Try a direct async connection if we have a DSN.
+    if dsn:
+        try:
+            async with await psycopg.AsyncConnection.connect(
+                dsn=dsn, connect_timeout=float(os.environ.get("DB_CONNECT_TIMEOUT", "5"))
+            ):
+                return True
+        except Exception:
+            return False
+
+    # No DSN at all.
+    return False
+
+
+async def close_pool() -> None:
+    """Close the pool if it exists."""
+    global _pool
+    if _pool is not None:
+        try:
+            await _pool.close()
+        finally:
+            _pool = None
+            logger.info("DB pool closed")

--- a/app/features/treasure/store.py
+++ b/app/features/treasure/store.py
@@ -10,13 +10,11 @@ from typing import Any
 
 import psycopg
 from psycopg.types.json import Json
-from psycopg_pool import AsyncConnectionPool
 
+from app.db.pool import get_pool
 from app.features.treasure.models import Session
 
 log = logging.getLogger("r4t.store")
-
-_pool: AsyncConnectionPool | None = None
 
 
 def _as_dict(val: Any) -> dict:
@@ -36,50 +34,39 @@ def _dsn() -> str:
     return dsn
 
 
-async def init_pool() -> None:
-    """Create the global async pool on startup and ensure schema."""
-    global _pool
-    if _pool is None:
-        _pool = AsyncConnectionPool(
-            conninfo=_dsn(),
-            min_size=1,
-            max_size=10,
-            kwargs={"autocommit": False},
-        )
-        # open explicitly to avoid deprecation warning
-        await _pool.open()
-        await ensure_schema()
+# ---------- schema management ----------
 
 
 async def ensure_schema() -> None:
-    assert _pool is not None
-    async with _pool.connection() as ac, ac.transaction():
-        await ac.execute("""
-                CREATE TABLE IF NOT EXISTS card_assets (
-                  oracle_id TEXT PRIMARY KEY,
-                  name TEXT,
-                  small_url TEXT,
-                  local_small_path TEXT,
-                  etag TEXT,
-                  last_modified TEXT,
-                  fetched_at TIMESTAMPTZ DEFAULT now()
-                )
-            """)
-
-
-async def close_pool() -> None:
-    global _pool
-    if _pool is not None:
-        await _pool.close()
-        _pool = None
+    """
+    Create tables required by this feature if they do not exist.
+    Uses the central async pool from app.db.pool.
+    """
+    pool = get_pool()
+    assert pool is not None, "DB pool not initialized"
+    async with pool.connection() as ac, ac.transaction():
+        await ac.execute(
+            """
+            CREATE TABLE IF NOT EXISTS card_assets (
+              oracle_id TEXT PRIMARY KEY,
+              name TEXT,
+              small_url TEXT,
+              local_small_path TEXT,
+              etag TEXT,
+              last_modified TEXT,
+              fetched_at TIMESTAMPTZ DEFAULT now()
+            )
+            """
+        )
 
 
 # ---------- sessions CRUD ----------
 
 
 async def create_session(s: Session) -> None:
-    assert _pool is not None, "Pool not initialized"
-    async with _pool.connection() as ac, ac.transaction():
+    pool = get_pool()
+    assert pool is not None, "DB pool not initialized"
+    async with pool.connection() as ac, ac.transaction():
         await ac.execute(
             "INSERT INTO sessions (id, data) VALUES (%s, %s)",
             (s.id, Json(s.model_dump())),
@@ -87,8 +74,9 @@ async def create_session(s: Session) -> None:
 
 
 async def load_session(sid: str) -> Session | None:
-    assert _pool is not None, "Pool not initialized"
-    async with _pool.connection() as ac, ac.transaction():
+    pool = get_pool()
+    assert pool is not None, "DB pool not initialized"
+    async with pool.connection() as ac, ac.transaction():
         cur = await ac.execute("SELECT data FROM sessions WHERE id=%s", (sid,))
         row = await cur.fetchone()
         if not row:
@@ -115,9 +103,12 @@ async def mutate_session(
     sid: str,
     mutator: Callable[[Session], Awaitable[None]] | Callable[[Session], None],
 ) -> Session:
-    """Serialize mutations per session id using row-level lock."""
-    assert _pool is not None, "Pool not initialized"
-    async with _pool.connection() as ac, ac.transaction():
+    """
+    Serialize mutations per session id using row-level lock.
+    """
+    pool = get_pool()
+    assert pool is not None, "DB pool not initialized"
+    async with pool.connection() as ac, ac.transaction():
         s = await _load_for_update(ac, sid)
         res = mutator(s)
         if asyncio.iscoroutine(res):
@@ -130,11 +121,16 @@ async def mutate_session(
 
 
 async def get_asset(oracle_id: str) -> dict | None:
-    assert _pool is not None
-    async with _pool.connection() as ac:
+    pool = get_pool()
+    assert pool is not None, "DB pool not initialized"
+    async with pool.connection() as ac:
         async with ac.transaction():
             cur = await ac.execute(
-                "SELECT oracle_id, name, small_url, local_small_path, etag, last_modified, fetched_at FROM card_assets WHERE oracle_id=%s",
+                """
+                SELECT oracle_id, name, small_url, local_small_path, etag, last_modified, fetched_at
+                FROM card_assets
+                WHERE oracle_id=%s
+                """,
                 (oracle_id,),
             )
             row = await cur.fetchone()
@@ -160,8 +156,9 @@ async def upsert_asset(
     etag: str | None,
     last_modified: str | None,
 ) -> None:
-    assert _pool is not None
-    async with _pool.connection() as ac:
+    pool = get_pool()
+    assert pool is not None, "DB pool not initialized"
+    async with pool.connection() as ac:
         async with ac.transaction():
             await ac.execute(
                 """
@@ -174,7 +171,7 @@ async def upsert_asset(
                     etag = EXCLUDED.etag,
                     last_modified = EXCLUDED.last_modified,
                     fetched_at = now()
-            """,
+                """,
                 (oracle_id, name, small_url, local_small_path, etag, last_modified),
             )
 
@@ -188,20 +185,21 @@ async def cleanup_expired_sessions_once(ttl_hours: int = 72) -> int:
     Assumes a schema with columns: id TEXT PK, data JSONB, created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ.
     Returns number of rows deleted.
     """
-    assert _pool is not None
+    pool = get_pool()
+    assert pool is not None, "DB pool not initialized"
     to_interval = f"{int(ttl_hours)} hours"
-    async with _pool.connection() as ac, ac.transaction():
+    async with pool.connection() as ac, ac.transaction():
         cur = await ac.execute(
             """
-                WITH base AS (
-                  SELECT id
-                  FROM sessions
-                  WHERE COALESCE(updated_at, created_at, now()) < (now() - %s::interval)
-                )
-                DELETE FROM sessions s USING base b
-                WHERE s.id = b.id
-                RETURNING s.id
-                """,
+            WITH base AS (
+              SELECT id
+              FROM sessions
+              WHERE COALESCE(updated_at, created_at, now()) < (now() - %s::interval)
+            )
+            DELETE FROM sessions s USING base b
+            WHERE s.id = b.id
+            RETURNING s.id
+            """,
             (to_interval,),
         )
         rows = await cur.fetchall()
@@ -218,9 +216,7 @@ async def periodic_cleanup(
 ) -> None:
     """
     Background loop to periodically call cleanup_expired_sessions_once.
-    Create a task on startup, cancel on shutdown:
-        app.state.cleanup_stop = asyncio.Event()
-        app.state.cleanup_task = asyncio.create_task(periodic_cleanup(72, 900, app.state.cleanup_stop))
+    Create/cancel lifecycle in app.startup/shutdown.
     """
     log.info("Starting periodic_cleanup loop (ttl=%sh, every=%ss)", ttl_hours, interval_seconds)
     try:

--- a/app/web/health.py
+++ b/app/web/health.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from fastapi import APIRouter
 
+from app.db.pool import check_ready as db_ready  # new import
+
 router = APIRouter(tags=["health"])
 
 
@@ -33,32 +35,9 @@ def _is_cache_writable() -> bool:
         return False
 
 
-async def _is_db_ready() -> bool:
-    """Best-effort DB readiness.
-
-    We haven't refactored DI yet (Milestone 2), so we try to import the current
-    store module and acquire a connection if the global pool exists.
-    """
-
-    try:
-        from app.features.treasure import store  # type: ignore  # noqa: PLC0415
-    except Exception:
-        store = None  # type: ignore[assignment]
-
-    pool = getattr(store, "_pool", None)
-    if pool is None:
-        return False
-
-    try:
-        async with pool.connection() as _conn:
-            return True
-    except Exception:
-        return False
-
-
 @router.get("/readyz")
 async def readyz() -> dict[str, str | bool]:
     cache_ok = _is_cache_writable()
-    db_ok = await _is_db_ready()
+    db_ok = await db_ready()
     status = "ok" if (cache_ok and db_ok) else "degraded"
     return {"status": status, "cache_writable": cache_ok, "db_ready": db_ok}

--- a/tests/test_db_pool_unit.py
+++ b/tests/test_db_pool_unit.py
@@ -1,0 +1,9 @@
+import asyncio
+
+from app.db import pool as dbpool
+
+
+def test_check_ready_false_when_uninitialized():
+    # Ensure pool is closed/None
+    asyncio.run(dbpool.close_pool())
+    assert asyncio.run(dbpool.check_ready()) is False


### PR DESCRIPTION
# Milestone 2: Centralized DB Pool & Health Integration

## Summary
This milestone consolidates database connection pooling into a single module and refactors dependent code to use it. Health checks and lifecycle hooks now operate against the central pool, providing consistent observability.

## Changes
- **New module**: `app/db/pool.py`  
  - Owns `init_pool`, `close_pool`, `get_pool`, `check_ready`.  
  - Handles both pooled connections (via `psycopg-pool`) and fallback direct connections.  

- **Refactor**: `app/features/treasure/store.py`  
  - Removed module-level `_pool`.  
  - All queries now call `get_pool()` from `app/db/pool`.  
  - `ensure_schema()` still provided to initialize required tables.

- **Update**: `app/main.py`  
  - Startup/shutdown hooks call `init_pool` / `close_pool`.  
  - `periodic_cleanup` shutdown made Ruff-clean.  

- **Update**: `app/web/health.py`  
  - `/readyz` now checks both cache writability and DB readiness.  

- **Tests**:  
  - `tests/test_health.py`: asserts degraded mode when DB unavailable.  
  - `tests/test_db_pool_unit.py`: confirms `check_ready()` behavior without a pool.  

## Verification
- ✅ `pre-commit run --all-files` passes (Ruff, format, mypy, etc.)  
- ✅ `pytest -q` passes locally.  
- ✅ Service restart works; `/healthz` and `/readyz` respond correctly.  

## Next Steps
- Merge into `main`.  
- Begin **Milestone 3: Configuration Cleanup** (consolidate `.env`, pyproject settings, secrets management).  
